### PR TITLE
fix: copy public folder to container directory

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - master
-      - dev
 
 jobs:
   lint-app:

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Add new routes for the model in the `🪧 routes` directory (e.g., `/routes/prov
 Create Zod schemas for query, response, params, and body in:<br>
 `server/src/scripts/openapi/docs/api.schema.ts`
 
-   > **INFO**<br>
+   > 💡 **INFO**<br>
    Follow the existing schema patterns in this file.
 
 5. **Add validation middleware**<br>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # Express server running in development mode
   weaponsforge-ph-regions:
     container_name: weaponsforge-ph-regions
-    image: weaponsforge/ph-regions
+    image: weaponsforge/ph-regions:latest
     env_file:
       - ./server/.env
     build:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,7 +9,7 @@ COPY package*.json ./
 FROM base AS build
 RUN npm install
 COPY . ./
-RUN npm run transpile
+RUN npm run transpile && npm run docs:build
 
 # DEVELOPMENT SETUP
 FROM base AS development-setup

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -31,6 +31,7 @@ CMD ["npm", "run", "docker:dev"]
 FROM base AS production
 ENV NODE_ENV production
 COPY package*.json ./
+COPY public ./public
 RUN npm ci --only=production && npm cache clean --force
 
 # Copy build output


### PR DESCRIPTION
- Fix: copy the API documentation artifacts (OpenAPI build output) to the container working directory - fixes running the production container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Enhanced INFO callouts in README with a 💡 emoji for clearer emphasis.
- Chores
  - CI: Pushes to the dev branch now run lint checks; master remains ignored.
  - Build/Deployment: Set an explicit :latest tag for the ph-regions image for predictable pulls.
  - Build: Production server image now includes the public/static assets so they’re available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->