### PR TITLE
feat: deploy to docker hub on create of new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Deploy to Production Environment
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker-build-push:
+    name: Push Development Image
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Build Image
+        run: |
+          cp server/.env.example server/.env
+          docker compose -f docker-compose.yml build
+
+      - name: Push Image to Docker Hub
+        run: docker compose -f docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A RESTful API that serves **hierarchical location data** of the Philippines — 
 - [Available Scripts](#-available-scripts)
 - [Docker Scripts](#-docker-scripts)
 - [Adding New Endpoints](#️-adding-new-endpoints)
+- [Usage with GitHub Actions](#usage-with-github-actions)
 - [References](#references)
 
 ### 📋 Requirements
@@ -108,6 +109,22 @@ The main app is inside the `📂 server/src` folder.
 ## ⚡ Usage
 
 ### 🐳 Using Docker
+
+### Use Pre-Built Development Docker Image
+
+https://hub.docker.com/r/weaponsforge/ph-regions
+
+1. Pull the development Docker image from Docker Hub using one of the options.<br>
+   - `docker pull weaponsforge/ph-regions:latest`
+   - `docker compose pull` (using Docker compose from the root project directory)
+
+2. Navigate to the project directory using the command line. Create a `.env` file inside the **/docs** directory with reference to the `.env.example` file.
+   - See [Installation](#️-installation) - **step # 3** for more information.
+
+3. Run the development Docker image.
+   - Proceed to **Build the Development Docker Image - step # 2** for more information.
+
+### Build the Development Docker Image
 
 1. Build the image.<br>
    ```sh
@@ -304,6 +321,29 @@ Perform manual tests to ensure everything works correctly.
 
 </details>
 <br>
+
+## Usage with GitHub Actions
+
+### Deployment to Docker Hub
+
+This repository deploys the latest development Docker image `weaponsforge/ph-regions:latest` to Docker Hub on the creation of new Tags/Releases with GitHub Actions. Supply the following GitHub Secrets and Variable to enable deployment to Docker Hub. It requires a Docker Hub account.
+
+The Docker Hub image is available at:
+
+https://hub.docker.com/r/weaponsforge/ph-regions
+
+#### GitHub Secrets
+
+| GitHub Secret | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | Docker Hub username |
+| DOCKERHUB_TOKEN | Deploy token for the Docker Hub account |
+
+#### GitHub Variables
+
+| GitHub Variable | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | Docker Hub username |
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A RESTful API that serves **hierarchical location data** of the Philippines — 
 - [Project Folder Structure](#-project-folder-structure)
 - [Installation](#️-installation)
 - [Usage](#-usage)
+   - [Using Docker](#-using-docker)
+   - [Alternate Usage Using Node](#-alternate-usage-using-node)
 - [Available Scripts](#-available-scripts)
 - [Docker Scripts](#-docker-scripts)
 - [Adding New Endpoints](#️-adding-new-endpoints)
@@ -110,7 +112,7 @@ The main app is inside the `📂 server/src` folder.
 
 ### 🐳 Using Docker
 
-### Use Pre-Built Development Docker Image
+### A. Use Pre-Built Development Docker Image
 
 https://hub.docker.com/r/weaponsforge/ph-regions
 
@@ -124,7 +126,7 @@ https://hub.docker.com/r/weaponsforge/ph-regions
 3. Run the development Docker image.
    - Proceed to **Build the Development Docker Image - step # 2** for more information.
 
-### Build the Development Docker Image
+### B. Build the Development Docker Image
 
 1. Build the image.<br>
    ```sh

--- a/README.md
+++ b/README.md
@@ -114,16 +114,21 @@ The main app is inside the `📂 server/src` folder.
 
 ### A. Use Pre-Built Development Docker Image
 
-https://hub.docker.com/r/weaponsforge/ph-regions
+See [Docker Hub: weaponsforge/ph-regions](https://hub.docker.com/r/weaponsforge/ph-regions)
 
 1. Pull the development Docker image from Docker Hub using one of the options.<br>
    - `docker pull weaponsforge/ph-regions:latest`
    - `docker compose pull` (using Docker compose from the root project directory)
 
-2. Navigate to the project directory using the command line. Create a `.env` file inside the **/docs** directory with reference to the `.env.example` file.
+2. Navigate to the project directory. Create a `.env` file at **server/.env** using **server/.env.example** as reference.
    - See [Installation](#️-installation) - **step # 3** for more information.
 
 3. Run the development Docker image.
+
+   - ```sh
+     docker compose up
+     ```
+
    - Proceed to **Build the Development Docker Image - step # 2** for more information.
 
 ### B. Build the Development Docker Image


### PR DESCRIPTION
- Feat: deploy the latest "development" image to Docker Hub on creation of new Release/Tag from the master branch, [#4](https://github.com/weaponsforge/ph-regions/issues/4) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with Docker usage guidance: use a pre-built development image, build your own, and added alternate Node-based usage.
  * Added “Usage with GitHub Actions” explaining deployment of the development Docker image and required secrets/variables; updated table of contents.

* **Chores**
  * Added a release workflow that runs on published releases to build and publish the development Docker image to the container registry (conditional on release target and registry credentials).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->