### PR TITLE
fix: vercel deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   release:
     types: [published]
 
+  push:
+    branches-ignore:
+      - master
+
 jobs:
   # Deploy server to Vercel
   deploy-vercel:
     name: Deploy Server to Vercel
-    if: github.event.release.target_commitish == 'master'
+    # if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -28,7 +32,7 @@ jobs:
           node-version: 24.11.0
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@47.0.6
+        run: npm install --global vercel@51.7.0
 
       - name: Build API docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,11 @@ on:
   release:
     types: [published]
 
-  push:
-    branches-ignore:
-      - master
-
 jobs:
   # Deploy server to Vercel
   deploy-vercel:
     name: Deploy Server to Vercel
-    # if: github.event.release.target_commitish == 'master'
+    if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ph-regions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ph-regions",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "cookie-parser": "^1.4.7",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-regions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "description": "A RESTful API that serves hierarchical location data of the Philippines — including regions, provinces, municipalities, and a randomly generated number of barangays per municipality.",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- Update the Vercel CLI to `v51.7.0` (latest version), fixing the recent Vercel deployment error where it detects mismatching Node v22 and v24 versions

## Type of Change
- [x] Bug fix
- [x] Other (please describe): CI/CD

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/weaponsforge/ph-regions/blob/dev/CONTRIBUTING.md)
- [x] I have tested my changes locally

## Screenshots 

<img width="1153" height="523" alt="vercel-fail" src="https://github.com/user-attachments/assets/882193f8-b7c2-4741-8d29-608aaa9946eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server package to version 1.1.3
  * Updated CI/CD deployment tools to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->